### PR TITLE
always show EXTRAM if it exists

### DIFF
--- a/teensy_size.c
+++ b/teensy_size.c
@@ -78,6 +78,7 @@ int main(int argc, char **argv)
 		uint32_t bss = elf_section_size(".bss");
 		uint32_t bss_dma = elf_section_size(".bss.dma");
 		uint32_t text_csf = elf_section_size(".text.csf");
+		uint32_t bss_extram = elf_section_size(".bss.extram");
 
 		uint32_t flash_total = text_headers + text_code + text_progmem
 			+ text_itcm + arm_exidx + data + text_csf;
@@ -120,12 +121,8 @@ int main(int argc, char **argv)
 			"%s   RAM2: variables:%u  free for malloc/new:%d\n",
 			(free_for_malloc < 0) ? "" : prefix,
 			ram2, free_for_malloc);
-		if (model == 0x25) {
-			uint32_t bss_extram = elf_section_size(".bss.extram");
-			if (bss_extram > 0) {
-				fprintf(fout,
-					"%s EXTRAM: variables:%u\n", prefix, bss_extram);
-			}
+		if (bss_extram > 0) {
+			fprintf(fout, "%s EXTRAM: variables:%u\n", prefix, bss_extram);
 		}
 		if (retval != 0) {
 			fprintf(fout,"Error program exceeds memory space\n");


### PR DESCRIPTION
When using custom hardware with the [MKL02 sold by PJRC](https://www.pjrc.com/store/ic_mkl02_t4.html), this program does not report EXTRAM when the region exists in the ld script. This makes a tweak so EXTRAM will always show if defined.

To test I...
- compiled [blink_slow.ino](https://github.com/PaulStoffregen/teensy_loader_cli/blob/master/blink_slow.ino) targeting teensy4.0 and ran this against the resulting elf; no EXTRAM info was provided.
- compiled [blink_slow.ino](https://github.com/PaulStoffregen/teensy_loader_cli/blob/master/blink_slow.ino) targeting teensy4.1 and ran this against the resulting elf; no EXTRAM info was provided.
- compiled [teensy41_psram_memtest.ino](https://github.com/PaulStoffregen/teensy41_psram_memtest/blob/master/teensy41_psram_memtest.ino) targeting teensy4.1 and ran this against the resulting elf; EXTRAM info _was_ provided.
- compiled a sketch for my custom variant  with `.bss.extram` configured for SDRAM;  EXTRAM info _was_ provided.